### PR TITLE
Implementing view storage through Inheritance

### DIFF
--- a/example/auto-move.cpp
+++ b/example/auto-move.cpp
@@ -20,6 +20,6 @@ int main()
     trace_t trace{};
 
     std::puts("==================");
-    std::array<trace_t, 3> result = +(std::move(trace) | rzx::as_ref | rzx::repeat<3>);
+    rzx::vec<3, trace_t> result = +(std::move(trace) | rzx::as_ref | rzx::repeat<3>);
     std::puts("==================");
 }

--- a/example/tensor.cpp
+++ b/example/tensor.cpp
@@ -63,8 +63,8 @@ int main()
     MAGIC_SHOW_TYPE(+exp);
     MAGIC_SHOW_TYPE(r);
     
-    //std::cout << r[0][0] << ", " << r[0][1] << '\n';
-    //std::cout << r[1][0] << ", " << r[1][1] << '\n';
+    std::cout << r.base()[0][0] << ", " << r.base()[0][1] << '\n';
+    std::cout << r.base()[1][0] << ", " << r.base()[1][1] << '\n';
     //std::array<std::array<double, 2>, 2> e{};
     //rzx::mat_mul(r, mat) >> e;
 

--- a/example/tensor.cpp
+++ b/example/tensor.cpp
@@ -12,8 +12,8 @@ void fooo()
 {
     using namespace ruzhouxie;
     mat<2, 2> m{ 
-        vec<2>{ 1.0, 2.0 },
-        vec<2>{ 3.0, 4.0 }
+        array{ 1.0, 2.0 },
+        array{ 3.0, 4.0 }
     };
 
     //mat<2, 2> mm = +mat_mul(m, m);
@@ -41,7 +41,7 @@ int main()
     
 
     //auto mat = std::array{ X{ 1, 2.0 }, X{ 3, 4.0 } };
-    auto mat = rzx::mat<2, 2>{ rzx::vec<2>{ 1.0, 2.0 }, rzx::vec<2>{ 3.0, 4.0 } };
+    auto mat = rzx::mat<2, 2>{ rzx::array{ 1.0, 2.0 }, rzx::array{ 3.0, 4.0 } };
     using mat_t = decltype(mat);
         // rzx::mat<2, 2>{ rzx::array{ 1.0, 2.0 }, rzx::array{ 3.0, 4.0 } };
     auto vec = rzx::array{ 1.0, 2.0 };
@@ -63,8 +63,8 @@ int main()
     MAGIC_SHOW_TYPE(+exp);
     MAGIC_SHOW_TYPE(r);
     
-    std::cout << r[0][0] << ", " << r[0][1] << '\n';
-    std::cout << r[1][0] << ", " << r[1][1] << '\n';
+    //std::cout << r[0][0] << ", " << r[0][1] << '\n';
+    //std::cout << r[1][0] << ", " << r[1][1] << '\n';
     //std::array<std::array<double, 2>, 2> e{};
     //rzx::mat_mul(r, mat) >> e;
 

--- a/include/ruzhouxie/general.h
+++ b/include/ruzhouxie/general.h
@@ -152,25 +152,13 @@ namespace ruzhouxie
     overload(Fn...) -> overload<std::decay_t<Fn>...>;
 
     template<typename T>
-    struct wrapper;
-
-    template<typename T> requires (not inheritable<T>)
-    struct wrapper<T>
+    struct wrapper
 	{
 	    T raw_value;
 
 	    constexpr decltype(auto) value(this auto&& self)noexcept
 		{
 		    return FWD(self, raw_value);
-		}
-	};
-
-    template<inheritable T>
-    struct wrapper<T> : T
-	{
-	    constexpr decltype(auto) value(this auto&& self)noexcept
-		{
-		    return rzx::as_base<T>(FWD(self));
 		}
 	};
 }

--- a/include/ruzhouxie/macro_define.h
+++ b/include/ruzhouxie/macro_define.h
@@ -10,18 +10,15 @@
 #define RUZHOUXIE_MAYBE_EMPTY [[no_unique_address]]
 #define RUZHOUXIE_INLINE [[clang::always_inline]]
 #define RUZHOUXIE_INLINE_LAMBDA [[clang::always_inline]]
-#define RUZHOUXIE_INLINE_CALLS
 #define RUZHOUXIE_INTRINSIC
 
 #else
 
 #ifdef _MSC_VER
 
-
 #define RUZHOUXIE_MAYBE_EMPTY [[msvc::no_unique_address]]
 #define RUZHOUXIE_INLINE [[msvc::forceinline]]
 #define RUZHOUXIE_INLINE_LAMBDA
-#define RUZHOUXIE_INLINE_CALLS [[msvc::forceinline_calls]]
 #define RUZHOUXIE_INTRINSIC [[msvc::intrinsic]]
 
 #else
@@ -29,7 +26,6 @@
 #define RUZHOUXIE_MAYBE_EMPTY [[no_unique_address]]
 #define RUZHOUXIE_INLINE
 #define RUZHOUXIE_INLINE_LAMBDA
-#define RUZHOUXIE_INLINE_CALLS
 #define RUZHOUXIE_INTRINSIC
 
 #endif

--- a/include/ruzhouxie/relayout.h
+++ b/include/ruzhouxie/relayout.h
@@ -30,12 +30,12 @@ namespace ruzhouxie
         RUZHOUXIE_MAYBE_EMPTY V base_view;
     
     private:
-        using strategy_t = relayout_view_child_Strategy;
-
         template<size_t I, specified<relayout_view> Self>
-        static consteval choice_t<strategy_t> child_Choose()
+        static consteval choice_t<relayout_view_child_Strategy> child_Choose()
         {
+            using strategy_t = relayout_view_child_Strategy;
             using layout_type = purified<decltype(Layout)>;
+
             if constexpr(I >= child_count<layout_type>)
             {
                 return { strategy_t::none, true };
@@ -62,7 +62,9 @@ namespace ruzhouxie
         RUZHOUXIE_INLINE friend constexpr decltype(auto) tag_invoke(tag_t<child<I>>, Self&& self)
             noexcept(child_Choose<I, Self>().nothrow)
         {
+            using strategy_t = relayout_view_child_Strategy;
             constexpr strategy_t strategy = child_Choose<I, Self>().strategy;
+            
             if constexpr (strategy == strategy_t::none)
             {
                 return;

--- a/include/ruzhouxie/relayout.h
+++ b/include/ruzhouxie/relayout.h
@@ -25,7 +25,7 @@ namespace ruzhouxie
     }
 
     template<typename V, auto Layout>
-    struct detail::relayout_view : view_base<relayout_view<V, Layout>>
+    struct detail::relayout_view : view_interface<relayout_view<V, Layout>>
     {
         RUZHOUXIE_MAYBE_EMPTY V base_view;
     

--- a/include/ruzhouxie/tape.h
+++ b/include/ruzhouxie/tape.h
@@ -265,14 +265,14 @@ namespace ruzhouxie
             {
                 return detail::relayout_view<decltype(FWD(self, data)), layout>
                 {
-                   {}, FWD(self, data)
+                   FWD(self, data)
                 };
             }
             else if constexpr(strategy == strategy_t::relayout_not_last)
             {
                 return detail::relayout_view<decltype(as_const(self.data)), layout>
                 {
-                    {}, as_const(self.data)
+                    as_const(self.data)
                 };
             }
             else
@@ -310,14 +310,14 @@ namespace ruzhouxie
             {
                 return detail::relayout_view<decltype(FWD(self, data)), layout>
                 {
-                   {}, FWD(self, data)
+                   FWD(self, data)
                 };
             }
             else if constexpr(strategy == strategy_t::relayout_not_last)
             {
                 return detail::relayout_view<decltype(as_const(self.data)), layout>
                 {
-                    {}, as_const(self.data)
+                    as_const(self.data)
                 };
             }
             else

--- a/include/ruzhouxie/tensor.h
+++ b/include/ruzhouxie/tensor.h
@@ -120,7 +120,7 @@ namespace ruzhouxie
 namespace ruzhouxie
 {
     template<typename T>
-    concept tree_view = std::derived_from<purified<T>, detail::view_base<purified<T>>>;
+    concept tree_view = std::derived_from<purified<T>, view_interface<purified<T>>>;
 
     template<typename L, typename R> requires tree_view<L> || tree_view<R>
     RUZHOUXIE_INLINE constexpr decltype(auto) operator+(L&& l, R&& r)noexcept

--- a/include/ruzhouxie/transform.h
+++ b/include/ruzhouxie/transform.h
@@ -22,7 +22,7 @@ namespace ruzhouxie
     }
 
     template<typename V, typename F>
-    struct detail::transform_view : view_base<transform_view<V, F>>
+    struct detail::transform_view : view_interface<transform_view<V, F>>
     {
         RUZHOUXIE_MAYBE_EMPTY V base;
         RUZHOUXIE_MAYBE_EMPTY F fn;
@@ -269,7 +269,7 @@ namespace ruzhouxie
     }
 
     template<typename Fn, typename...Views>
-    struct detail::zip_transform_view : view_base<zip_transform_view<Fn, Views...>>
+    struct detail::zip_transform_view : view_interface<zip_transform_view<Fn, Views...>>
     {
         RUZHOUXIE_MAYBE_EMPTY Fn fn;
         RUZHOUXIE_MAYBE_EMPTY tuple<Views...> views;

--- a/include/ruzhouxie/tree_view.h
+++ b/include/ruzhouxie/tree_view.h
@@ -47,16 +47,22 @@ namespace ruzhouxie
     template<typename T>
     struct view : wrapper<T>, detail::view_base<view<T>>
     {
+        template<specified<view> Self>
+        RUZHOUXIE_INLINE constexpr auto&& base(this Self&& self)
+        {
+            return rzx::as_base<wrapper<T>>(FWD(self)).value();
+        }
+
         template<size_t I, specified<view> Self> requires (I >= child_count<T>)
         RUZHOUXIE_INLINE friend constexpr void tag_invoke(tag_t<child<I>>, Self&& self){}
 
         template<size_t I, specified<view> Self> requires (I < child_count<T>)
         RUZHOUXIE_INLINE friend constexpr auto tag_invoke(tag_t<child<I>>, Self&& self)
-            AS_EXPRESSION(rzx::as_base<wrapper<T>>(FWD(self)).value() | child<I>)
+            AS_EXPRESSION(FWD(self).base() | child<I>)
 
         template<auto Seq, specified<view> Self>
         RUZHOUXIE_INLINE friend constexpr auto tag_invoke(tag_t<get_tape<Seq>>, Self&& self)
-            AS_EXPRESSION(rzx::as_base<wrapper<T>>(FWD(self)).value() | get_tape<Seq>)
+            AS_EXPRESSION(FWD(self).base() | get_tape<Seq>)
 
         template<std::same_as<view> V>
         friend consteval auto tag_invoke(tag_t<make_tree<V>>)

--- a/include/ruzhouxie/tree_view.h
+++ b/include/ruzhouxie/tree_view.h
@@ -7,7 +7,7 @@
 #include "processer.h"
 #include "macro_define.h"
 
-//view_base
+//view_interface
 namespace ruzhouxie
 {
     template<typename T>
@@ -28,24 +28,24 @@ namespace ruzhouxie
                 return FWD(self, raw_view) | make_tree<U>;
             }
         };
-
-        template<typename View>
-        struct view_base
-        {
-            template<typename Self>
-            RUZHOUXIE_INLINE constexpr auto operator+(this Self&& self)noexcept
-            {
-                return universal_view<Self&&>{ FWD(self) };
-            }
-        };
     }
+    
+    template<typename View>
+    struct view_interface
+    {
+        template<typename Self>
+        RUZHOUXIE_INLINE constexpr auto operator+(this Self&& self)noexcept
+        {
+            return detail::universal_view<Self&&>{ FWD(self) };
+        }
+    };
 }
 
 //view
 namespace ruzhouxie
 {
     template<typename T>
-    struct view : wrapper<T>, detail::view_base<view<T>>
+    struct view : wrapper<T>, view_interface<view<T>>
     {
         template<specified<view> Self>
         RUZHOUXIE_INLINE constexpr auto&& base(this Self&& self)

--- a/include/ruzhouxie/tree_view.h
+++ b/include/ruzhouxie/tree_view.h
@@ -28,6 +28,18 @@ namespace ruzhouxie
                 return FWD(self, raw_view) | make_tree<U>;
             }
         };
+        
+        template<typename V>
+        struct view_base
+	    {
+	        V base_view;
+
+            template<specified<view_base> Self>
+	        RUZHOUXIE_INLINE constexpr decltype(auto) base(this Self&& self)noexcept
+		    {
+		        return FWD(self, base_view);
+		    }
+	    };
     }
     
     template<typename View>
@@ -39,6 +51,8 @@ namespace ruzhouxie
             return detail::universal_view<Self&&>{ FWD(self) };
         }
     };
+
+    
 }
 
 //view

--- a/include/ruzhouxie/tree_view.h
+++ b/include/ruzhouxie/tree_view.h
@@ -59,14 +59,8 @@ namespace ruzhouxie
 namespace ruzhouxie
 {
     template<typename T>
-    struct view : wrapper<T>, view_interface<view<T>>
+    struct view : detail::view_base<T>, view_interface<view<T>>
     {
-        template<specified<view> Self>
-        RUZHOUXIE_INLINE constexpr auto&& base(this Self&& self)
-        {
-            return rzx::as_base<wrapper<T>>(FWD(self)).value();
-        }
-
         template<size_t I, specified<view> Self> requires (I >= child_count<T>)
         RUZHOUXIE_INLINE friend constexpr void tag_invoke(tag_t<child<I>>, Self&& self){}
 


### PR DESCRIPTION
This allows view to maintain the copy elision of aggregate class construction while conveniently using CRTP view_interface, without the need to write an additional empty curly brace during construction.
old:
```
struct xxx_view : view_interface<xxx_view>
{
    T base;
};

auto v = xxx_view{ {}, t };
```
new:
```
struct xxx_view : view_base<T>, view_interface<xxx_view>
{};

auto v = xxx_view{ t };
```